### PR TITLE
Improve first time setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ UBC Snowbots repo for the 2017 intelligent ground vehicle competition
 ## Setup
 - Install Ubuntu (We recommend you use a minimum of 30GB of space) ([Windows Instructions](http://www.tecmint.com/install-ubuntu-16-04-alongside-with-windows-10-or-8-in-dual-boot/), [Mac Instructions](http://www.howtogeek.com/187410/how-to-install-and-dual-boot-linux-on-a-mac/))
 - Boot into Ubuntu
-- Setup your UBC alumni email account [here](https://id.ubc.ca/) and then get a JetBrains education accout [here](https://www.jetbrains.com/shop/eform/students). You will use this to active CLion later on
+- Setup your UBC alumni email account [here](https://id.ubc.ca/) and then get a JetBrains education account [here](https://www.jetbrains.com/shop/eform/students). _You will get 2 emails from JetBrains, the first one is to confirm your email and the other is to active your account. You will use this to active CLion later on._
 - Clone this repository by running `git clone https://github.com/UBC-Snowbots/IGVC-2017.git ~/IGVC-2017`
 - Install everything you'll need to get started by running `cd ~/IGVC-2017 && ./get_started.sh` (Just choose yes and enter your password when needed throughout) **(Do not run this script as root)**
 - Build the ROS project by running `source /opt/ros/kinetic/setup.bash` and `cd ~/IGVC-2017 && catkin_make`. If everything compiles correctly and you don't get any error's, then you're good to go!
 
 ## Important Notes:
 - To run CLion with ROS, you must first go in to terminal, navigate to your project (`cd ~/IGVC-2017`), run `source devel/setup.sh` and then **from the same terminal** run `clion`
-- CLion will not support autocompletion in your *.cpp* and *.h* files until you've added them to the CMake file
+- CLion will not support auto-completion in your *.cpp* and *.h* files until you've added them to the CMake file
 
 ## What Should **NOT** Go In This Repo
 - photos or videos (that aren't needed for the system to run)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ if you're on campus use the `ubcsecure` network for best results.
     - For dual-booting: [Windows Instructions](http://www.tecmint.com/install-ubuntu-16-04-alongside-with-windows-10-or-8-in-dual-boot/), [Mac Instructions](http://www.howtogeek.com/187410/how-to-install-and-dual-boot-linux-on-a-mac/)
 2. If you haven't done so already, setup your UBC alumni email account [here](https://id.ubc.ca/) 
 3. Using your UBC email account, get a JetBrains education account [here](https://www.jetbrains.com/shop/eform/students). 
-    - _You will get 2 emails from JetBrains, the first one confirms your UBC email and the other actives your account._
+    - _You will get 2 emails from JetBrains, the first one is to confirm your UBC email and the second is to activate your new education account._
     - _You will use the activated account to set up CLion later on._
 4. Boot into Ubuntu for the remaining steps
 5. Clone this repository by running `git clone https://github.com/UBC-Snowbots/IGVC-2017.git ~/IGVC-2017`

--- a/README.md
+++ b/README.md
@@ -1,18 +1,22 @@
 # IGVC-2017
 UBC Snowbots repo for the 2017 intelligent ground vehicle competition
 
-
 ## Setup
-- Install Ubuntu (We recommend you use a minimum of 30GB of space) ([Windows Instructions](http://www.tecmint.com/install-ubuntu-16-04-alongside-with-windows-10-or-8-in-dual-boot/), [Mac Instructions](http://www.howtogeek.com/187410/how-to-install-and-dual-boot-linux-on-a-mac/))
-- Boot into Ubuntu
-- Setup your UBC alumni email account [here](https://id.ubc.ca/) and then get a JetBrains education account [here](https://www.jetbrains.com/shop/eform/students). 
-    - _You will get 2 emails from JetBrains, the first one is to confirm your email and the other is to active your account._
-    - _You will use the activated account for CLion later on._
-- Clone this repository by running `git clone https://github.com/UBC-Snowbots/IGVC-2017.git ~/IGVC-2017`
-- Install everything you'll need to get started by running `cd ~/IGVC-2017 && ./get_started.sh` **(Do not run this script as root)**
-    - _Just choose yes and enter your password when needed throughout_ 
-- Build the ROS project by running `source /opt/ros/kinetic/setup.bash` and `cd ~/IGVC-2017 && catkin_make`. 
-    - If everything compiles correctly and you don't get any error's, then you're good to go!
+```
+You will be downloading an Ubuntu ISO and multiple ROS packages with their respective dependencies.
+It is highly recommended that you have access to high speed internet while doing this entire setup; if you're on campus use the ubcsecure network.
+```
+1. Install Ubuntu 16.04 (We recommend you use a minimum of 30GB of space) 
+    - For dual-booting: [Windows Instructions](http://www.tecmint.com/install-ubuntu-16-04-alongside-with-windows-10-or-8-in-dual-boot/), [Mac Instructions](http://www.howtogeek.com/187410/how-to-install-and-dual-boot-linux-on-a-mac/)
+2. Boot into Ubuntu for the remaining steps
+3. Setup your UBC alumni email account [here](https://id.ubc.ca/) and then get a JetBrains education account [here](https://www.jetbrains.com/shop/eform/students). 
+    - _You will get 2 emails from JetBrains, the first one confirms your email and the other actives your account._
+    - _You will use the activated account to set up CLion later on._
+4. Clone this repository by running `git clone https://github.com/UBC-Snowbots/IGVC-2017.git ~/IGVC-2017`
+5. To start set-up run `cd ~/IGVC-2017 && ./get_started.sh` **(Do not run this script as root)**
+    - _Just choose yes and enter your password when the terminal prompts you_ 
+6. Build the ROS project by running `source /opt/ros/kinetic/setup.bash` and `cd ~/IGVC-2017 && catkin_make`. 
+    - If everything compiles correctly and you don't get any errors, then you're good to go!
 
 ## Important Notes:
 - To run CLion with ROS, you must first go in to terminal, navigate to your project (`cd ~/IGVC-2017`), run `source devel/setup.sh` and then **from the same terminal** run `clion`

--- a/README.md
+++ b/README.md
@@ -5,10 +5,14 @@ UBC Snowbots repo for the 2017 intelligent ground vehicle competition
 ## Setup
 - Install Ubuntu (We recommend you use a minimum of 30GB of space) ([Windows Instructions](http://www.tecmint.com/install-ubuntu-16-04-alongside-with-windows-10-or-8-in-dual-boot/), [Mac Instructions](http://www.howtogeek.com/187410/how-to-install-and-dual-boot-linux-on-a-mac/))
 - Boot into Ubuntu
-- Setup your UBC alumni email account [here](https://id.ubc.ca/) and then get a JetBrains education account [here](https://www.jetbrains.com/shop/eform/students). _You will get 2 emails from JetBrains, the first one is to confirm your email and the other is to active your account. You will use this to active CLion later on._
+- Setup your UBC alumni email account [here](https://id.ubc.ca/) and then get a JetBrains education account [here](https://www.jetbrains.com/shop/eform/students). 
+    - _You will get 2 emails from JetBrains, the first one is to confirm your email and the other is to active your account._
+    - _You will use the activated account for CLion later on._
 - Clone this repository by running `git clone https://github.com/UBC-Snowbots/IGVC-2017.git ~/IGVC-2017`
-- Install everything you'll need to get started by running `cd ~/IGVC-2017 && ./get_started.sh` (Just choose yes and enter your password when needed throughout) **(Do not run this script as root)**
-- Build the ROS project by running `source /opt/ros/kinetic/setup.bash` and `cd ~/IGVC-2017 && catkin_make`. If everything compiles correctly and you don't get any error's, then you're good to go!
+- Install everything you'll need to get started by running `cd ~/IGVC-2017 && ./get_started.sh` **(Do not run this script as root)**
+    - _Just choose yes and enter your password when needed throughout_ 
+- Build the ROS project by running `source /opt/ros/kinetic/setup.bash` and `cd ~/IGVC-2017 && catkin_make`. 
+    - If everything compiles correctly and you don't get any error's, then you're good to go!
 
 ## Important Notes:
 - To run CLion with ROS, you must first go in to terminal, navigate to your project (`cd ~/IGVC-2017`), run `source devel/setup.sh` and then **from the same terminal** run `clion`

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ if you're on campus use the `ubcsecure` network for best results.
 2. If you haven't done so already, setup your UBC alumni email account [here](https://id.ubc.ca/) 
 3. Using your UBC email account, get a JetBrains education account [here](https://www.jetbrains.com/shop/eform/students). 
     - _JetBrains will send an initial email to confirm the UBC email you inputted, 
-    once you confirm another email will be sent to activate your new education account. 
-    You will use the activated education account to set up CLion later on._
+    once you confirm another email will be sent to activate your new education account; 
+    you will use this account to set up CLion later on._
 4. Boot into Ubuntu for the remaining steps
 5. Clone this repository by running `git clone https://github.com/UBC-Snowbots/IGVC-2017.git ~/IGVC-2017`
 6. To start set-up run `cd ~/IGVC-2017 && ./get_started.sh` **(Do not run this script as root)**

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ UBC Snowbots repo for the 2017 intelligent ground vehicle competition
 - Boot into Ubuntu
 - Setup your UBC alumni email account [here](https://id.ubc.ca/) and then get a JetBrains education accout [here](https://www.jetbrains.com/shop/eform/students). You will use this to active CLion later on
 - Clone this repository by running `git clone https://github.com/UBC-Snowbots/IGVC-2017.git ~/IGVC-2017`
-- Install everything you'll need to get started by running `cd ~/IGVC-2017 && ./install_required.sh` (Just choose yes and enter your password when needed throughout) **(Do not run this script as root)**
-- Build the ROS project by running `cd ~/IGVC-2017 && catkin_make`. If everything compiles correctly and you don't get any error's, then you're good to go!
+- Install everything you'll need to get started by running `cd ~/IGVC-2017 && ./get_started.sh` (Just choose yes and enter your password when needed throughout) **(Do not run this script as root)**
+- Build the ROS project by running `source /opt/ros/kinetic/setup.bash` and `cd ~/IGVC-2017 && catkin_make`. If everything compiles correctly and you don't get any error's, then you're good to go!
 
 ## Important Notes:
 - To run CLion with ROS, you must first go in to terminal, navigate to your project (`cd ~/IGVC-2017`), run `source devel/setup.sh` and then **from the same terminal** run `clion`

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 UBC Snowbots repo for the 2017 intelligent ground vehicle competition
 
 ## Setup
-```
+
 You will be downloading an Ubuntu ISO and multiple ROS packages with their respective dependencies.
-It is highly recommended that you have access to high speed internet while doing this entire setup; if you're on campus use the ubcsecure network.
-```
+It is highly recommended that you have access to high speed internet while doing this entire setup; 
+if you're on campus use the ubcsecure network for best results.
+
 1. Install Ubuntu 16.04 (We recommend you use a minimum of 30GB of space) 
     - For dual-booting: [Windows Instructions](http://www.tecmint.com/install-ubuntu-16-04-alongside-with-windows-10-or-8-in-dual-boot/), [Mac Instructions](http://www.howtogeek.com/187410/how-to-install-and-dual-boot-linux-on-a-mac/)
 2. Boot into Ubuntu for the remaining steps

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ if you're on campus use the `ubcsecure` network for best results.
     - For dual-booting: [Windows Instructions](http://www.tecmint.com/install-ubuntu-16-04-alongside-with-windows-10-or-8-in-dual-boot/), [Mac Instructions](http://www.howtogeek.com/187410/how-to-install-and-dual-boot-linux-on-a-mac/)
 2. If you haven't done so already, setup your UBC alumni email account [here](https://id.ubc.ca/) 
 3. Using your UBC email account, get a JetBrains education account [here](https://www.jetbrains.com/shop/eform/students). 
-    - _JetBrains will send an initial email to confirm the UBC email you inputted, once you confirm another email will be sent to activate your new education account._
-    - _You will use the activated education account to set up CLion later on._
+    - _JetBrains will send an initial email to confirm the UBC email you inputted, 
+    once you confirm another email will be sent to activate your new education account. 
+    You will use the activated education account to set up CLion later on._
 4. Boot into Ubuntu for the remaining steps
 5. Clone this repository by running `git clone https://github.com/UBC-Snowbots/IGVC-2017.git ~/IGVC-2017`
 6. To start set-up run `cd ~/IGVC-2017 && ./get_started.sh` **(Do not run this script as root)**

--- a/README.md
+++ b/README.md
@@ -5,18 +5,19 @@ UBC Snowbots repo for the 2017 intelligent ground vehicle competition
 
 You will be downloading an Ubuntu ISO and multiple ROS packages with their respective dependencies.
 It is highly recommended that you have access to high speed internet while doing this entire setup; 
-if you're on campus use the ubcsecure network for best results.
+if you're on campus use the `ubcsecure` network for best results.
 
 1. Install Ubuntu 16.04 (We recommend you use a minimum of 30GB of space) 
     - For dual-booting: [Windows Instructions](http://www.tecmint.com/install-ubuntu-16-04-alongside-with-windows-10-or-8-in-dual-boot/), [Mac Instructions](http://www.howtogeek.com/187410/how-to-install-and-dual-boot-linux-on-a-mac/)
-2. Boot into Ubuntu for the remaining steps
-3. Setup your UBC alumni email account [here](https://id.ubc.ca/) and then get a JetBrains education account [here](https://www.jetbrains.com/shop/eform/students). 
-    - _You will get 2 emails from JetBrains, the first one confirms your email and the other actives your account._
+2. If you haven't done so already, setup your UBC alumni email account [here](https://id.ubc.ca/) 
+3. Using your UBC email account, get a JetBrains education account [here](https://www.jetbrains.com/shop/eform/students). 
+    - _You will get 2 emails from JetBrains, the first one confirms your UBC email and the other actives your account._
     - _You will use the activated account to set up CLion later on._
-4. Clone this repository by running `git clone https://github.com/UBC-Snowbots/IGVC-2017.git ~/IGVC-2017`
-5. To start set-up run `cd ~/IGVC-2017 && ./get_started.sh` **(Do not run this script as root)**
+4. Boot into Ubuntu for the remaining steps
+5. Clone this repository by running `git clone https://github.com/UBC-Snowbots/IGVC-2017.git ~/IGVC-2017`
+6. To start set-up run `cd ~/IGVC-2017 && ./get_started.sh` **(Do not run this script as root)**
     - _Just choose yes and enter your password when the terminal prompts you_ 
-6. Build the ROS project by running `source /opt/ros/kinetic/setup.bash` and `cd ~/IGVC-2017 && catkin_make`. 
+7. Build the ROS project by running `source /opt/ros/kinetic/setup.bash` and `cd ~/IGVC-2017 && catkin_make`. 
     - If everything compiles correctly and you don't get any errors, then you're good to go!
 
 ## Important Notes:

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ if you're on campus use the `ubcsecure` network for best results.
     - For dual-booting: [Windows Instructions](http://www.tecmint.com/install-ubuntu-16-04-alongside-with-windows-10-or-8-in-dual-boot/), [Mac Instructions](http://www.howtogeek.com/187410/how-to-install-and-dual-boot-linux-on-a-mac/)
 2. If you haven't done so already, setup your UBC alumni email account [here](https://id.ubc.ca/) 
 3. Using your UBC email account, get a JetBrains education account [here](https://www.jetbrains.com/shop/eform/students). 
-    - _You will get 2 emails from JetBrains, the first one is to confirm your UBC email and the second is to activate your new education account._
-    - _You will use the activated account to set up CLion later on._
+    - _JetBrains will send an initial email to confirm the UBC email you inputted, once you confirm another email will be sent to activate your new education account._
+    - _You will use the activated education account to set up CLion later on._
 4. Boot into Ubuntu for the remaining steps
 5. Clone this repository by running `git clone https://github.com/UBC-Snowbots/IGVC-2017.git ~/IGVC-2017`
 6. To start set-up run `cd ~/IGVC-2017 && ./get_started.sh` **(Do not run this script as root)**

--- a/get_started.sh
+++ b/get_started.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+echo "================================================================"
+echo "Starting first time installation and setup, please wait"
+echo "these downloads can take a while if you're on slow internet."
+echo "================================================================"
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -60,9 +64,12 @@ echo 'alias clion="clion & disown && exit"' >> ~/.zshrc
 echo 'alias rviz="rviz & disown && exit"' >> ~/.bashrc
 echo 'alias rviz="rviz & disown && exit"' >> ~/.zshrc
 
-
 ###############################
 # Install Other Dependencies
 ###############################
 cd $DIR
 ./install_dependencies.sh
+
+echo "================================================================"
+echo "Finished first time installation and setup; you're good to go!"
+echo "================================================================"

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -4,6 +4,10 @@
 # This script will download and install dependencies for the project #
 ######################################################################
 
+echo "================================================================"
+echo "Installing other ROS dependencies..."
+echo "================================================================"
+
 sudo apt-get install -y\
     ros-kinetic-xacro \
     ros-kinetic-controller-manager \
@@ -11,3 +15,7 @@ sudo apt-get install -y\
     ros-kinetic-ros-controllers \
     ros-kinetic-ros-control \
     ros-kinetic-effort-controllers
+
+echo "================================================================"
+echo "Finished installing other ROS dependencies."
+echo "================================================================"


### PR DESCRIPTION
- Add high speed internet recommendation
- Add command to source the setup.bash file, for first time setup this wasn't done automatically.
- Update JetBrain step with additional info
- Use number list instead of bullet point list for setup step
- Improve UX with addition of echo statements to bash scripts; this will give the user some indication of what is happening, otherwise they won't know when the set up has completed.