### PR TITLE
Fixed sb_gazebo nodes not being compile

### DIFF
--- a/src/sb_gazebo/CMakeLists.txt
+++ b/src/sb_gazebo/CMakeLists.txt
@@ -10,6 +10,9 @@ find_package(catkin REQUIRED COMPONENTS
 
 add_definitions(-std=c++14)
 
+catkin_package(
+#  INCLUDE_DIRS include
+)
 
 ###########
 ## Build ##


### PR DESCRIPTION
If `catkin_package()` is not in the CMakeLists.txt, it causes issues, such as nodes not being compiled. Re-added to sb_gazebo.