### PR TITLE
Reoriented the Gazebo Zed's pointcloud

### DIFF
--- a/src/sb_gazebo/CMakeLists.txt
+++ b/src/sb_gazebo/CMakeLists.txt
@@ -6,6 +6,8 @@ project(sb_gazebo)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
   gazebo_ros
+  tf2_ros
+  tf2_sensor_msgs
 )
 
 add_definitions(-std=c++14)
@@ -27,6 +29,7 @@ include_directories(
 
 ## Declare a C++ executable
 # add_executable(gazebo_node src/gazebo_node.cpp)
+add_executable(zed_transform src/zed_transform.cpp)
 
 ## Specify libraries to link a library or executable target against
 # target_link_libraries(gazebo_node
@@ -43,3 +46,4 @@ include_directories(
 # if(TARGET ${PROJECT_NAME}-test)
 #   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
 # endif()
+target_link_libraries(zed_transform ${catkin_LIBRARIES})

--- a/src/sb_gazebo/CMakeLists.txt
+++ b/src/sb_gazebo/CMakeLists.txt
@@ -10,6 +10,8 @@ find_package(catkin REQUIRED COMPONENTS
   tf2_sensor_msgs
 )
 
+find_package(sb_utils REQUIRED)
+
 add_definitions(-std=c++14)
 
 catkin_package(
@@ -24,7 +26,9 @@ catkin_package(
 ## Your package locations should be listed before other locations
 # include_directories(include)
 include_directories(
-  ${catkin_INCLUDE_DIRS}
+    ${catkin_INCLUDE_DIRS}
+    ${sb_utils_INCLUDE_DIRS}
+    ./include
 )
 
 ## Declare a C++ executable
@@ -35,6 +39,7 @@ add_executable(zed_transform src/zed_transform.cpp)
 # target_link_libraries(gazebo_node
 #   ${catkin_LIBRARIES}
 # )
+target_link_libraries(zed_transform ${catkin_LIBRARIES} ${sb_utils_LIBRARIES})
 
 
 #############
@@ -46,4 +51,3 @@ add_executable(zed_transform src/zed_transform.cpp)
 # if(TARGET ${PROJECT_NAME}-test)
 #   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
 # endif()
-target_link_libraries(zed_transform ${catkin_LIBRARIES})

--- a/src/sb_gazebo/launch/general_robot_control.launch
+++ b/src/sb_gazebo/launch/general_robot_control.launch
@@ -13,4 +13,7 @@
         <remap from="/joint_states" to="/robot/joint_states" />
     </node>
 
+    <!-- This is for jfrost's Zed module -->
+    <!-- <node name="zed_transform" pkg="sb_gazebo" type="zed_transform" output="screen" /> -->
+
 </launch>

--- a/src/sb_gazebo/launch/general_robot_control.launch
+++ b/src/sb_gazebo/launch/general_robot_control.launch
@@ -13,7 +13,6 @@
         <remap from="/joint_states" to="/robot/joint_states" />
     </node>
 
-    <!-- This is for jfrost's Zed module -->
-    <!-- <node name="zed_transform" pkg="sb_gazebo" type="zed_transform" output="screen" /> -->
+
 
 </launch>

--- a/src/sb_gazebo/launch/jfrost_control.launch
+++ b/src/sb_gazebo/launch/jfrost_control.launch
@@ -18,7 +18,12 @@
     <arg name="robot" value="jfrost"/>
   </include>
 
-  <!-- This is for jfrost's Zed module -->
-  <node name="zed_transform" pkg="sb_gazebo" type="zed_transform" output="screen" />
+  <!-- This is for jfrost's depthcamera/kinect/zed plugin -->
+  <node name="zed_transform" pkg="sb_gazebo" type="zed_transform" output="screen">
+    <rosparam param="output_frame"> "zed_pointcloud" </rosparam>
+    
+    <remap from="/input_pointcloud" to="/zed/camera/point_cloud/uncorrected_cloud_do_not_use"/>
+    <remap from="/output_pointcloud" to="/zed/camera/point_cloud/cloud_registered"/>
+  </node>
 
 </launch>

--- a/src/sb_gazebo/launch/jfrost_control.launch
+++ b/src/sb_gazebo/launch/jfrost_control.launch
@@ -16,6 +16,9 @@
 
   <include file="$(find sb_gazebo)/launch/general_robot_control.launch">
     <arg name="robot" value="jfrost"/>
-  </include> 
+  </include>
+
+  <!-- This is for jfrost's Zed module -->
+  <node name="zed_transform" pkg="sb_gazebo" type="zed_transform" output="screen" />
 
 </launch>

--- a/src/sb_gazebo/launch/open_world.launch
+++ b/src/sb_gazebo/launch/open_world.launch
@@ -31,5 +31,4 @@
     <!-- push robot_description to factory and spawn robot in gazebo -->
     <node name="robot_spawn" pkg="gazebo_ros" type="spawn_model" output="screen"
      args="-urdf -param robot_description -model $(arg robot) -x $(arg x_start_coordinate) -y $(arg y_start_coordinate) -Y $(arg initial_rotation)" />
-
 </launch>

--- a/src/sb_gazebo/package.xml
+++ b/src/sb_gazebo/package.xml
@@ -41,7 +41,9 @@
   <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>gazebo_ros</build_depend>
+  <build_depend>tf2_sensor_msgs</build_depend>
   <run_depend>gazebo_ros</run_depend>
+  <run_depend>tf2_sensor_msgs</run_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/src/sb_gazebo/src/zed_transform.cpp
+++ b/src/sb_gazebo/src/zed_transform.cpp
@@ -1,0 +1,48 @@
+/*
+ * Created By: Valerian Ratu
+ * Created On: May 1 2017
+ * Description: A node which transforms the pointcloud output on the Zed
+ *              of the gazebo simulation
+ */
+
+#include <sensor_msgs/PointCloud2.h>
+#include <ros/ros.h>
+#include <tf2_ros/transform_listener.h>
+#include <tf2_sensor_msgs/tf2_sensor_msgs.h>
+
+ros::Publisher pub;
+
+void pointCloudCallback(const sensor_msgs::PointCloud2::ConstPtr& msg) {
+    try {
+
+        sensor_msgs::PointCloud2 output;
+        tf2_ros::Buffer tfBuffer;
+        tf2_ros::TransformListener tfListener(tfBuffer);
+        geometry_msgs::TransformStamped tstamped;
+        tstamped = tfBuffer.lookupTransform(msg->header.frame_id, "zed_pointcloud", ros::Time(0), ros::Duration(1.0));
+        ROS_INFO("Frame %s -> %s", msg->header.frame_id.c_str(), "zed_pointcloud");
+        ROS_INFO("Transform: x:%f y:%f z:%f x:%f y:%f z:%f w:%f",
+                 tstamped.transform.translation.x,
+                 tstamped.transform.translation.y,
+                 tstamped.transform.translation.z,
+                 tstamped.transform.rotation.x,
+                 tstamped.transform.rotation.y,
+                 tstamped.transform.rotation.z,
+                 tstamped.transform.rotation.w);
+        tf2::doTransform(*msg, output, tstamped);
+        pub.publish(output);
+
+    } catch (tf2::TransformException ex){
+        ROS_WARN("%s", ex.what());
+        ros::Duration(1.0).sleep();
+    }
+}
+
+int main(int argc, char** argv){
+    ros::init(argc, argv, "zed_transform");
+    ros::NodeHandle nh;
+    pub = nh.advertise<sensor_msgs::PointCloud2>("/zed/camera/point_cloud/cloud_corrected", 1);
+    ros::Subscriber sub = nh.subscribe("/zed/camera/point_cloud/cloud_registered", 1, pointCloudCallback);
+    ros::spin();
+    return 0;
+}

--- a/src/sb_gazebo/urdf/jfrost.gazebo
+++ b/src/sb_gazebo/urdf/jfrost.gazebo
@@ -78,7 +78,7 @@
         <depthImageTopicName>/zed/depth/image_raw</depthImageTopicName>
         <depthImageInfoTopicName>/zed/depth/camera_info</depthImageInfoTopicName>
         <pointCloudTopicName>/zed/camera/point_cloud/cloud_registered</pointCloudTopicName>
-        <frameName>zed_pointcloud</frameName>
+        <frameName>camera</frameName>
         <pointCloudCutoff>0.5</pointCloudCutoff>
         <distortionK1>0.00000001</distortionK1>
         <distortionK2>0.00000001</distortionK2>

--- a/src/sb_gazebo/urdf/jfrost.gazebo
+++ b/src/sb_gazebo/urdf/jfrost.gazebo
@@ -77,7 +77,7 @@
         <cameraInfoTopicName>/zed/depth/camera_info</cameraInfoTopicName>
         <depthImageTopicName>/zed/depth/image_raw</depthImageTopicName>
         <depthImageInfoTopicName>/zed/depth/camera_info</depthImageInfoTopicName>
-        <pointCloudTopicName>/zed/camera/point_cloud/cloud_registered</pointCloudTopicName>
+        <pointCloudTopicName>/zed/camera/point_cloud/uncorrected_cloud_do_not_use</pointCloudTopicName>
         <frameName>camera</frameName>
         <pointCloudCutoff>0.5</pointCloudCutoff>
         <distortionK1>0.00000001</distortionK1>

--- a/src/sb_utils/include/sb_utils.h
+++ b/src/sb_utils/include/sb_utils.h
@@ -12,6 +12,9 @@
 #define UTILS_UTILS_H
 
 #include <ros/ros.h>
+#include <geometry_msgs/TransformStamped.h>
+#include <tf2_ros/transform_listener.h>
+#include <tf2_ros/buffer.h>
 
 /**
  * Get a param with a default value
@@ -64,6 +67,23 @@ bool SB_getParam(ros::NodeHandle& nh, const std::string& param_name, T& param_va
         return false;
     }
     return true;
+}
+
+/**
+ * Transforms a given message from it's current frame to another frame
+ *
+ * @param input the message to be transformed
+ * @param output the transformed message will be placed in this
+ * @param output_frame the frame to transform the input to
+ */
+template <typename T>
+void SB_doTransform(const T& input, T& output, std::string output_frame){
+    tf2_ros::Buffer tfBuffer;
+    tf2_ros::TransformListener tfListener(tfBuffer);
+    geometry_msgs::TransformStamped transformStamped = tfBuffer.lookupTransform(
+            input.header.frame_id, output_frame, ros::Time(0), ros::Duration(1.0)
+    );
+    tf2::doTransform(input, output, transformStamped);
 }
 
 #endif //UTILS_UTILS_H


### PR DESCRIPTION
Note of 
```
tfBuffer.lookupTransform(msg->header.frame_id, "zed_pointcloud", ros::Time(0), ros::Duration(1.0));
```
where the `target_frame` and `source_frame` seems to be switched. I swear to god the transform is proper. So either this is a bug, can't confirm since my tf knowledge is abysmal, or I'm dumb and I'm not declaring frames correctly (more likely).
Anyhow it all works :tm: .